### PR TITLE
Poe website was trying to access save repository /poe.com

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,7 +85,7 @@ These are simply the hosts of the LLMs, which include:
 10. [Llama2](https://www.llama2.ai)
 11. [Blackboxai](https://www.blackbox.ai)
 12. [gpt4all](https://gpt4all.io) *(Offline)*
-13. [Poe](poe.com) - Poe|Quora *(Session ID required)*
+13. [Poe](https://poe.com) - Poe|Quora *(Session ID required)*
 
 
 <details>


### PR DESCRIPTION
Just you missed the `https://` so it was not going to that website rather trying to access the page in github and giving a 404 error page.